### PR TITLE
Add CI workflow for tests and security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Scan Dockerfile with Trivy
         id: trivy_scan
-        uses: aquasecurity/trivy-action@v0.21.0
+        uses: aquasecurity/trivy-action@v0.20.0
         continue-on-error: true
         with:
           scan-type: config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Scan Dockerfile with Trivy
         id: trivy_scan
-        uses: aquasecurity/trivy-action@v0.20.0
+        uses: aquasecurity/trivy-action@v0.21.0
         continue-on-error: true
         with:
           scan-type: config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  tests-and-scans:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pip-audit
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=. --cov-report=xml --cov-report=html
+
+      - name: Run pip-audit security scan
+        id: pip_audit
+        continue-on-error: true
+        run: |
+          pip-audit -r requirements.txt -f json -o pip-audit.json
+
+      - name: Scan Dockerfile with Trivy
+        id: trivy_scan
+        uses: aquasecurity/trivy-action@v0.20.0
+        continue-on-error: true
+        with:
+          scan-type: config
+          scan-ref: .
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          format: json
+          output: trivy-report.json
+
+      - name: Upload coverage reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            coverage.xml
+            htmlcov/
+
+      - name: Upload security scan report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: pip-audit.json
+
+      - name: Upload Trivy scan report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: trivy-report.json
+
+      - name: Fail on security scan findings
+        if: ${{ steps.pip_audit.outcome == 'failure' || steps.trivy_scan.outcome == 'failure' }}
+        run: |
+          echo "Security scans reported issues. See uploaded artifacts for details." >&2
+          exit 1


### PR DESCRIPTION
## Summary
- add CI workflow that runs on pushes to main and pull requests
- install Python dependencies, execute pytest with coverage, and persist coverage artifacts
- add pip-audit and Trivy scans with artifact uploads and enforced failures on findings

## Testing
- `pytest --cov=. --cov-report=xml --cov-report=html`


------
https://chatgpt.com/codex/tasks/task_e_68d7e4bc78608322bf56bb2cbad794a5