### PR TITLE
Add correlation ID utilities and tests

### DIFF
--- a/tests/test_correlation_ids.py
+++ b/tests/test_correlation_ids.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils import (
+    bind_request_correlation_id,
+    clear_correlation_id,
+    correlation_context,
+    ensure_correlation_id,
+    extract_correlation_id_from_request,
+    generate_correlation_id,
+    get_correlation_id,
+    get_logger,
+    validate_correlation_id,
+)
+
+
+class DummyRequest:
+    def __init__(self, headers=None, query_params=None):
+        self.headers = headers or {}
+        self.query_params = query_params or {}
+
+
+def test_generate_and_validate_roundtrip():
+    correlation_id = generate_correlation_id()
+    assert validate_correlation_id(correlation_id)
+
+
+def test_correlation_context_resets_previous_value():
+    with correlation_context("123e4567-e89b-12d3-a456-426614174000"):
+        assert get_correlation_id() == "123e4567-e89b-12d3-a456-426614174000"
+        with correlation_context():
+            nested_id = get_correlation_id()
+            assert validate_correlation_id(nested_id)
+        # after exiting nested context original ID restored
+        assert get_correlation_id() == "123e4567-e89b-12d3-a456-426614174000"
+    assert get_correlation_id() is None
+
+
+def test_get_logger_attaches_correlation_id(monkeypatch):
+    records: list[logging.LogRecord] = []
+
+    handler = logging.Handler()
+    handler.emit = records.append  # type: ignore[assignment]
+
+    base_logger = logging.getLogger("utils-test")
+    base_logger.handlers = [handler]
+    base_logger.setLevel(logging.INFO)
+    base_logger.propagate = False
+
+    adapter = get_logger("utils-test")
+
+    known_id = "123e4567-e89b-12d3-a456-426614174000"
+    with correlation_context(known_id):
+        adapter.info("testing")
+
+    assert records, "Expected a log record to be emitted"
+    assert getattr(records[0], "correlation_id", None) == known_id
+
+
+def test_extract_correlation_id_from_request_prefers_header():
+    request = DummyRequest(headers={"x-request-id": "123e4567-e89b-12d3-a456-426614174000"})
+    assert (
+        extract_correlation_id_from_request(request)
+        == "123e4567-e89b-12d3-a456-426614174000"
+    )
+
+
+def test_extract_correlation_id_from_request_falls_back_to_params():
+    request = DummyRequest(query_params={"correlation_id": "123e4567-e89b-12d3-a456-426614174000"})
+    assert (
+        extract_correlation_id_from_request(request)
+        == "123e4567-e89b-12d3-a456-426614174000"
+    )
+
+
+def test_bind_request_correlation_id_sets_context():
+    request = DummyRequest(headers={"x-request-id": "123e4567-e89b-12d3-a456-426614174000"})
+    with bind_request_correlation_id(request) as correlation_id:
+        assert correlation_id == "123e4567-e89b-12d3-a456-426614174000"
+        assert get_correlation_id() == correlation_id
+    assert get_correlation_id() is None
+
+
+def test_ensure_correlation_id_generates_when_missing():
+    clear_correlation_id()
+    generated = ensure_correlation_id(None)
+    assert validate_correlation_id(generated)
+    clear_correlation_id()
+    assert get_correlation_id() is None
+

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,195 @@
 from __future__ import annotations  # Fixed: double underscores, not asterisks
-import re, time, json, csv, threading
-from typing import Dict, List, Generator, Iterable, Any
-from collections import deque, defaultdict
+
+import contextlib
+import contextvars
+import csv
+import json
+import logging
+import re
+import threading
+import time
+import uuid
+from collections import defaultdict
 from pathlib import Path
+from typing import Any, Dict, Generator, Iterable, List
 
 SANITIZE_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F]")
+
+
+# --- Correlation ID helpers -------------------------------------------------
+_correlation_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "correlation_id", default=None
+)
+_DEFAULT_HEADER_NAME = "x-request-id"
+
+
+def generate_correlation_id() -> str:
+    """Return a new UUID4 string suitable for trace/correlation identifiers."""
+
+    return str(uuid.uuid4())
+
+
+def validate_correlation_id(value: str | None) -> bool:
+    """Return ``True`` when *value* looks like a valid UUID string."""
+
+    if not value:
+        return False
+    try:
+        uuid.UUID(str(value))
+    except (ValueError, TypeError, AttributeError):
+        return False
+    return True
+
+
+def get_correlation_id(default: str | None = None) -> str | None:
+    """Fetch the correlation ID stored in the current context.
+
+    Parameters
+    ----------
+    default:
+        Value returned when the context does not yet contain an identifier.
+    """
+
+    value = _correlation_id_var.get()
+    return value or default
+
+
+def set_correlation_id(correlation_id: str) -> str:
+    """Persist *correlation_id* in the current context after validation."""
+
+    if not validate_correlation_id(correlation_id):
+        raise ValueError("correlation_id must be a valid UUID string")
+    _correlation_id_var.set(correlation_id)
+    return correlation_id
+
+
+def clear_correlation_id() -> None:
+    """Remove the correlation identifier from the active context."""
+
+    _correlation_id_var.set(None)
+
+
+@contextlib.contextmanager
+def correlation_context(correlation_id: str | None = None):
+    """Context manager that binds a correlation ID for the duration of a block.
+
+    Usage pattern::
+
+        with correlation_context():
+            logger = get_logger(__name__)
+            logger.info("message")  # records auto-include the correlation_id
+
+    Passing an explicit ``correlation_id`` allows upstream middleware to
+    propagate a known identifier.  When omitted, a new UUID4 is generated.
+    """
+
+    if correlation_id and validate_correlation_id(correlation_id):
+        new_id = correlation_id
+    else:
+        # Generate a fresh identifier to avoid propagating untrusted values.
+        new_id = generate_correlation_id()
+    token = _correlation_id_var.set(new_id)
+    try:
+        yield new_id
+    finally:
+        _correlation_id_var.reset(token)
+
+
+class CorrelationIdAdapter(logging.LoggerAdapter):
+    """Attach the active correlation ID to every log record."""
+
+    def process(self, msg: str, kwargs: dict[str, Any]):
+        correlation_id = get_correlation_id()
+        extra = kwargs.setdefault("extra", {})
+        extra.setdefault("correlation_id", correlation_id)
+        return msg, kwargs
+
+
+def get_logger(name: str | None = None) -> CorrelationIdAdapter:
+    """Return a ``LoggerAdapter`` that injects the current correlation ID.
+
+    The adapter preserves familiar ``logging`` semantics while ensuring
+    downstream handlers can rely on ``record.correlation_id`` being present.
+    Modules should call this helper rather than ``logging.getLogger`` directly.
+    """
+
+    base_logger = logging.getLogger(name or __name__)
+    return CorrelationIdAdapter(base_logger, {})
+
+
+def extract_correlation_id_from_request(
+    request: Any | None,
+    *,
+    header_name: str = _DEFAULT_HEADER_NAME,
+) -> str | None:
+    """Fetch a correlation ID from the provided Gradio/Starlette request object."""
+
+    if request is None:
+        return None
+
+    # ``gr.Request`` provides Starlette's ``headers`` and ``query_params``
+    # interfaces. Both are case-insensitive mappings.
+    header_value = None
+    headers = getattr(request, "headers", None)
+    if headers is not None:
+        try:
+            header_value = headers.get(header_name) or headers.get(header_name.upper())
+        except AttributeError:
+            header_value = headers.get(header_name) if isinstance(headers, dict) else None
+
+    candidate = header_value or None
+    if candidate and validate_correlation_id(candidate):
+        return candidate
+
+    # Fall back to query parameters when no header is present.
+    params = getattr(request, "query_params", None)
+    if params is not None:
+        try:
+            candidate = params.get(header_name) or params.get("correlation_id")
+        except AttributeError:
+            candidate = params.get(header_name) if isinstance(params, dict) else None
+        if candidate and validate_correlation_id(candidate):
+            return candidate
+
+    return None
+
+
+@contextlib.contextmanager
+def bind_request_correlation_id(
+    request: Any | None,
+    *,
+    header_name: str = _DEFAULT_HEADER_NAME,
+):
+    """Middleware-style helper to bind a request correlation ID.
+
+    Example
+    -------
+    ```python
+    def handler(request: gr.Request):
+        with bind_request_correlation_id(request):
+            logger = get_logger(__name__)
+            logger.info("Handling request")
+            ...
+    ```
+
+    The helper accepts ``None`` for compatibility with tests or Gradio
+    callbacks that omit a request object.  A new UUID is generated when the
+    incoming message lacks an identifier.
+    """
+
+    existing = extract_correlation_id_from_request(request, header_name=header_name)
+    with correlation_context(existing):
+        yield get_correlation_id()
+
+
+def ensure_correlation_id(request: Any | None = None) -> str:
+    """Ensure a correlation ID is available, storing it in the current context."""
+
+    existing = extract_correlation_id_from_request(request)
+    if existing:
+        set_correlation_id(existing)
+        return existing
+    return set_correlation_id(generate_correlation_id())
 
 def sanitize_text(s: str, max_chars: int) -> str:
     s = SANITIZE_RE.sub("", s or "")


### PR DESCRIPTION
## Summary
- add correlation ID generation/validation helpers with contextvar storage and logging adapter
- provide request-scoped middleware helpers to bind correlation IDs throughout the stack
- cover correlation ID utilities with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8126582cc83228e8ebbf0c205c2c6