### PR TITLE
Add chat integration tests and fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator, List
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
+
+try:  # pragma: no cover - dependency shim for tests
+    import structlog  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    class _ProcessorFormatter:
+        wrap_for_formatter = staticmethod(lambda *args, **kwargs: None)
+
+    structlog = SimpleNamespace(  # type: ignore[assignment]
+        processors=SimpleNamespace(  # type: ignore[arg-type]
+            TimeStamper=lambda fmt, key: (
+                lambda logger, method, event_dict: event_dict
+            ),
+            JSONRenderer=lambda: (
+                lambda logger, method, event_dict: event_dict
+            ),
+            add_log_level=lambda logger, method, event_dict: event_dict,
+            StackInfoRenderer=lambda logger, method, event_dict: event_dict,
+            format_exc_info=lambda logger, method, event_dict: event_dict,
+        ),
+        contextvars=SimpleNamespace(
+            merge_contextvars=lambda logger=None, method=None, event_dict=None: event_dict
+            or {},
+            bind_contextvars=lambda **kwargs: None,
+            clear_contextvars=lambda: None,
+        ),
+        dev=SimpleNamespace(
+            ConsoleRenderer=lambda: (
+                lambda logger, method, event_dict: event_dict
+            )
+        ),
+        stdlib=SimpleNamespace(
+            ProcessorFormatter=_ProcessorFormatter,
+            BoundLogger=SimpleNamespace,
+            LoggerFactory=lambda: None,
+        ),
+        configure=lambda **kwargs: None,
+        get_logger=lambda *args, **kwargs: SimpleNamespace(
+            info=lambda *a, **k: None,
+            error=lambda *a, **k: None,
+            exception=lambda *a, **k: None,
+        ),
+    )
+    sys.modules.setdefault("structlog", structlog)
+    sys.modules.setdefault("structlog.contextvars", structlog.contextvars)
+
+import main  # noqa: E402
+from utils import clear_correlation_id, sanitize_text  # noqa: E402
+
+
+@pytest_asyncio.fixture(scope="session")
+def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """Provide a dedicated asyncio loop for async tests.
+
+    Ensures isolation from the global loop when pytest-asyncio is active.
+    """
+
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+def fixtures_path() -> Path:
+    return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="session")
+def conversation_state(fixtures_path: Path) -> List[dict[str, str]]:
+    """Load a sanitized conversation history shared across tests."""
+
+    json_path = fixtures_path / "minimal_conversation.json"
+    yaml_path = fixtures_path / "minimal_conversation.yaml"
+
+    with json_path.open("r", encoding="utf-8") as handle:
+        json_history = json.load(handle)
+
+    # JSON is valid YAML; reuse json parser to keep dependencies minimal.
+    with yaml_path.open("r", encoding="utf-8") as handle:
+        yaml_history = json.load(handle)
+
+    assert yaml_history == json_history, "JSON and YAML fixtures must stay in sync"
+
+    max_chars = getattr(main.settings, "max_input_chars", 4096)
+    sanitized_history: List[dict[str, str]] = []
+    for entry in json_history:
+        sanitized_history.append(
+            {
+                "role": entry["role"],
+                "content": sanitize_text(entry.get("content", ""), max_chars),
+            }
+        )
+    return sanitized_history
+
+
+class MockChatCompletionCreate:
+    """Configurable mock for ``client.chat.completions.create``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+        self._chunks: list[object] = []
+        self._exception: Exception | None = None
+
+    def queue_chunks(self, chunks: Iterable[object]) -> None:
+        self._chunks = list(chunks)
+        self._exception = None
+
+    def queue_exception(self, exc: Exception) -> None:
+        self._chunks = []
+        self._exception = exc
+
+    def __call__(self, *args, **kwargs) -> Iterator[object]:
+        self.calls.append((args, kwargs))
+        if self._exception is not None:
+            raise self._exception
+
+        def _iterator() -> Iterator[object]:
+            for chunk in self._chunks:
+                yield chunk
+
+        return _iterator()
+
+
+@pytest.fixture
+def mock_client(monkeypatch) -> MockChatCompletionCreate:
+    mock = MockChatCompletionCreate()
+    monkeypatch.setattr(main.client.chat.completions, "create", mock)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def reset_correlation_context():
+    clear_correlation_id()
+    yield
+    clear_correlation_id()

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures package for conversation samples."""

--- a/tests/fixtures/minimal_conversation.json
+++ b/tests/fixtures/minimal_conversation.json
@@ -1,0 +1,5 @@
+[
+  {"role": "system", "content": "You are a helpful assistant."},
+  {"role": "user", "content": "Hello assistant!"},
+  {"role": "assistant", "content": "Hello there!"}
+]

--- a/tests/fixtures/minimal_conversation.yaml
+++ b/tests/fixtures/minimal_conversation.yaml
@@ -1,0 +1,5 @@
+[
+  {"role": "system", "content": "You are a helpful assistant."},
+  {"role": "user", "content": "Hello assistant!"},
+  {"role": "assistant", "content": "Hello there!"}
+]

--- a/tests/test_chat_integration.py
+++ b/tests/test_chat_integration.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import main
+import utils
+from utils import sanitize_text
+
+
+def _chunk(content: str | None = None, usage: object | None = None) -> SimpleNamespace:
+    delta = SimpleNamespace(content=content)
+    choice = SimpleNamespace(delta=delta)
+    chunk = SimpleNamespace(choices=[choice])
+    if usage is not None:
+        chunk.usage = usage
+    return chunk
+
+
+def _stub_logger():
+    return SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        exception=lambda *a, **k: None,
+    )
+
+
+def test_chat_streaming_success(mock_client, conversation_state, monkeypatch):
+    monkeypatch.setattr(main, "logger", _stub_logger())
+    monkeypatch.setattr(main.limiter, "check", lambda _ip: True)
+
+    usage = SimpleNamespace(prompt_tokens=5, completion_tokens=7)
+    mock_client.queue_chunks([_chunk("Hello"), _chunk(" world", usage)])
+
+    noisy_message = "Streaming sanitized message\x07"
+    expected_message = sanitize_text(noisy_message, main.settings.max_input_chars)
+    request = SimpleNamespace(client=SimpleNamespace(host="10.0.0.1"))
+
+    outputs = list(
+        main.chat_fn(noisy_message, conversation_state, "openai/gpt-integration", 0.3, "", request)
+    )
+
+    assert outputs == ["Hello", "Hello world"]
+    assert len(mock_client.calls) == 1
+
+    _args, kwargs = mock_client.calls[0]
+    assert kwargs["model"] == "openai/gpt-integration"
+    assert kwargs["stream"] is True
+
+    messages = kwargs["messages"]
+    assert messages[-1]["content"] == expected_message
+    assert messages[0]["role"] == "system"
+
+
+def test_chat_stream_error_path(mock_client, conversation_state, monkeypatch):
+    monkeypatch.setattr(main, "logger", _stub_logger())
+    monkeypatch.setattr(main.limiter, "check", lambda _ip: True)
+
+    mock_client.queue_exception(RuntimeError("boom"))
+
+    request = SimpleNamespace(client=SimpleNamespace(host="10.0.0.2"))
+    outputs = list(
+        main.chat_fn("trigger", conversation_state, "openai/gpt-integration", 0.1, "", request)
+    )
+
+    assert outputs == ["[API Error] RuntimeError: boom"]
+    assert len(mock_client.calls) == 1
+
+    _args, kwargs = mock_client.calls[0]
+    assert kwargs["stream"] is True
+
+
+def test_chat_rate_limit(monkeypatch, mock_client, conversation_state):
+    monkeypatch.setattr(main, "logger", _stub_logger())
+    monkeypatch.setattr(utils.RateLimiter, "check", lambda self, _ip: False)
+    monkeypatch.setattr(main, "limiter", utils.RateLimiter(capacity_per_min=1))
+    assert main.limiter.check("test-client") is False
+
+    request = SimpleNamespace(client=SimpleNamespace(host="10.0.0.3"))
+    outputs = list(
+        main.chat_fn("hello", conversation_state, "openai/gpt-integration", 0.1, "", request)
+    )
+
+    assert outputs == ["Rate limit exceeded. Please slow down and try again."]
+    assert mock_client.calls == []


### PR DESCRIPTION
## Summary
- add shared pytest fixtures for OpenRouter chat integration tests, including sanitized conversation samples
- patch the OpenRouter client and correlation ID context for deterministic testing
- cover streaming, error, and rate-limit paths for the chat handler

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8184400f48322b91a61f503e9d46c