### PR TITLE
Add pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3.12
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+        language_version: python3.12
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-docstrings==1.7.0
+        language_version: python3.12
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-requests
+        args:
+          - --python-version=3.12
+        language_version: python3.12

--- a/README.md
+++ b/README.md
@@ -110,7 +110,15 @@ pip install -r requirements.txt
 # Configure environment
 cp .env.example .env
 # Edit .env and set OPENROUTER_API_KEY=your_key_here
+
+# Install Git hooks (optional but recommended)
+pre-commit install
 ```
+
+Installing the Git hooks ensures the configured formatters, linters, and type
+checkers run automatically before each commit. Re-run `pre-commit install`
+after cloning the repository or whenever the `.pre-commit-config.yaml` file is
+updated to keep the hooks in sync with the project configuration.
 
 **Verification:**
 


### PR DESCRIPTION
## Summary
- add a pre-commit configuration covering formatting, linting, type checking, and basic hygiene checks
- document installing the pre-commit Git hooks so contributors run automated checks before committing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8313f580483228f035526d8522fec