### PR TITLE
Add example environment configuration file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,54 @@
+# Application metadata
+APP_TITLE="OpenRouter AI Assistant"
+# Optional URL included in OpenRouter requests for rate limiting / compliance reporting.
+APP_REFERER="https://your-domain.example"
+# Optional title shown for X/Twitter linkouts.
+APP_X_TITLE="Follow us on X"
+
+# API credentials (required)
+# Obtain from https://openrouter.ai/keys. Never commit real secrets.
+OPENROUTER_API_KEY="your-openrouter-api-key-here"
+# Override only if pointing at a proxy-compatible endpoint.
+# BASE_URL is fixed in code to https://openrouter.ai/api/v1 and cannot be changed here.
+
+# Model defaults
+# Default model identifier sent to OpenRouter (see https://openrouter.ai/models).
+DEFAULT_MODEL="openai/gpt-4o"
+# Sampling temperature in [0.0, 2.0]; higher values increase randomness.
+TEMPERATURE=0.3
+# Maximum user prompt length before truncation (100-50000 characters).
+MAX_INPUT_CHARS=8000
+# Maximum chat history messages to retain in memory (1-200).
+MAX_HISTORY_MESSAGES=40
+
+# Rate limiting
+# Max requests per minute per user/IP (1-1000).
+RATE_LIMIT_REQUESTS_PER_MIN=60
+
+# Analytics controls
+# Enable structured analytics events (true/false, yes/no, 1/0).
+ENABLE_ANALYTICS=true
+
+# Server binding
+# Host interface for the Gradio app (0.0.0.0 to expose externally).
+HOST=0.0.0.0
+# Listening port (1024-65535). 7860 is Gradio default.
+PORT=7860
+
+# Logging configuration
+# Minimum log level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+LOG_LEVEL=INFO
+# Emit logs as JSON (true) or human-readable console output (false).
+LOG_JSON=true
+# File path for rotating log handler. Parent directories are created automatically.
+LOG_PATH="logs/app.log"
+# Rotation schedule for log file (e.g., midnight, H, D, W0-W6).
+LOG_ROTATION_WHEN=midnight
+# Rotation interval multiplier (1-1440). With WHEN=midnight, 1 = daily rotation.
+LOG_ROTATION_INTERVAL=1
+# Number of rotated log files to retain (1-365).
+LOG_BACKUP_COUNT=7
+
+# Networking
+# Comma-separated list of trusted proxy IPs (leave blank if not behind proxies).
+TRUSTED_PROXIES="127.0.0.1,10.0.0.1"


### PR DESCRIPTION
## Summary
- add a project-wide `.env.example` to document all configuration variables consumed by `config.Settings`
- document safe defaults, ranges, and usage guidance for logging, rate limits, analytics, and proxies

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d86cfe4b288322ae6ef9093e72e136