### PR TITLE
ci: publish GHCR image and add deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 permissions:
   contents: read
+  packages: write
   security-events: write
 
 on:
@@ -49,6 +50,28 @@ jobs:
         continue-on-error: true
         run: |
           pip-audit -r requirements.txt -f json -o pip-audit.json
+
+      # Container registry publication requires GHCR_TOKEN configured in repository secrets.
+      - name: Authenticate to GitHub Container Registry
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          if [ -z "${GHCR_TOKEN}" ]; then
+            echo "GHCR_TOKEN secret is not configured." >&2
+            exit 1
+          fi
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
+
+      - name: Build Docker image for GHCR
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
+
+      - name: Push Docker image to GHCR
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
 
       - name: Trivy (SARIF for code scanning)
         id: trivy_sarif

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,81 @@
+name: Deploy
+
+# Requires GHCR_TOKEN, DEPLOY_SSH_KEY, DEPLOY_HOST, DEPLOY_USERNAME, and OPENROUTER_API_KEY secrets configured.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Authenticate to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          if [ -z "${GHCR_TOKEN}" ]; then
+            echo "GHCR_TOKEN secret is not configured." >&2
+            exit 1
+          fi
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
+
+      - name: Pull release image
+        run: |
+          docker pull ghcr.io/${{ github.repository }}:${{ github.event.workflow_run.head_sha }}
+
+      - name: Configure SSH for deployment target
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USERNAME: ${{ secrets.DEPLOY_USERNAME }}
+        run: |
+          if [ -z "${DEPLOY_SSH_KEY}" ] || [ -z "${DEPLOY_HOST}" ] || [ -z "${DEPLOY_USERNAME}" ]; then
+            echo "Deployment secrets are missing. Ensure DEPLOY_SSH_KEY, DEPLOY_HOST, and DEPLOY_USERNAME are set." >&2
+            exit 1
+          fi
+          install -m 700 -d ~/.ssh
+          echo "${DEPLOY_SSH_KEY}" | tr -d '\r' > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          cat <<CONFIG >> ~/.ssh/config
+Host production
+  HostName ${DEPLOY_HOST}
+  User ${DEPLOY_USERNAME}
+  IdentityFile ~/.ssh/id_ed25519
+  StrictHostKeyChecking accept-new
+CONFIG
+
+      - name: Deploy updated container
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          REGISTRY_USERNAME: ${{ github.repository_owner }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          if [ -z "${DEPLOY_HOST}" ]; then
+            echo "DEPLOY_HOST is not configured." >&2
+            exit 1
+          fi
+          if [ -z "${OPENROUTER_API_KEY}" ]; then
+            echo "OPENROUTER_API_KEY secret is not configured." >&2
+            exit 1
+          fi
+          ssh -o BatchMode=yes production <<REMOTE
+          set -euo pipefail
+          docker login ghcr.io -u "${REGISTRY_USERNAME}" --password-stdin <<< "${GHCR_TOKEN}"
+          docker pull ghcr.io/${{ github.repository }}:${{ github.event.workflow_run.head_sha }}
+          docker stop openrouter-chat || true
+          docker rm openrouter-chat || true
+          docker run -d --name openrouter-chat --restart always -p 7860:7860 \
+            -e OPENROUTER_API_KEY="${OPENROUTER_API_KEY}" \
+            ghcr.io/${{ github.repository }}:${{ github.event.workflow_run.head_sha }}
+          REMOTE


### PR DESCRIPTION
## Summary
- push the built container image to GitHub Container Registry from the CI workflow when main is updated
- add a deployment workflow that runs after a successful CI build on main and pulls the GHCR image before redeploying
- document the required secrets for registry access and production deployment credentials directly in the workflows

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d87b02a05c83229ade5eb1f6d01f9d