### PR TITLE
Add CI artifact ignores to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# CI-generated reports
+pip-audit.json
+pip-audit.sarif
+trivy-report.json
+trivy-results.sarif
+
+# Test and coverage artifacts
+.pytest_cache/
+.coverage
+coverage.xml
+
+# Logs and temporary files
+logs/
+*.log
+
+# Python caches
+__pycache__/
+*.pyc
+
+# Environment and virtualenv directories
+.env
+.venv/
+
+# OS-specific files
+.DS_Store


### PR DESCRIPTION
## Summary
- add a repository-level .gitignore file
- ignore pip-audit and Trivy reports along with other CI-generated artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d882fb7be483229fe8897e70980f4c