### PR TITLE
Add integration and e2e tests for streaming workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ required_plugins = [
 testpaths = [
   "tests",
 ]
+markers = [
+  "integration: integration tests exercising real storage and streaming",
+  "e2e: end-to-end workflow scenarios",
+]
 
 [tool.coverage.run]
 source = [

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests package."""

--- a/tests/e2e/test_user_workflows.py
+++ b/tests/e2e/test_user_workflows.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import main
+
+pytestmark = pytest.mark.e2e
+
+
+def test_full_user_workflow(
+    fake_openai_stream,
+    mock_openai_client,
+    app_storage,
+):
+    """Simulate conversation creation, messaging, export, and re-import."""
+
+    conversations: list[dict] = []
+    new_convo = main.create_new_conversation(conversations)
+    conversations.append(new_convo)
+
+    history = new_convo["history"]
+    user_message = "How are you?"
+
+    mock_openai_client.queue_stream(fake_openai_stream(["I'm", " great today!"]))
+    request = SimpleNamespace(client=SimpleNamespace(host="192.0.2.55"))
+
+    responses = list(
+        main.chat_fn(
+            message=user_message,
+            history=history,
+            model=main.settings.default_model,
+            temperature=0.5,
+            system_prompt="Stay positive",
+            request=request,
+        )
+    )
+
+    assistant_reply = responses[-1]
+    history.append({"role": "user", "content": user_message})
+    history.append({"role": "assistant", "content": assistant_reply})
+
+    main.save_conversations(conversations)
+
+    # Verify persistence writes the expected structure
+    persisted = json.loads(app_storage.conversations_file.read_text(encoding="utf-8"))
+    assert persisted[0]["history"][-1]["content"] == assistant_reply
+
+    export_path = Path(main.export_handler(history))
+    assert export_path.exists()
+
+    imported_history = main.import_handler(str(export_path), history)
+    assert imported_history == history
+
+    # Loading back from disk should match what we saved previously
+    loaded_state = main.load_conversations()
+    assert loaded_state[0]["history"][-1]["content"] == assistant_reply

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+"""Integration tests package."""
+

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,2 +1,1 @@
 """Integration tests package."""
-

--- a/tests/integration/test_rate_limiter_concurrency.py
+++ b/tests/integration/test_rate_limiter_concurrency.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+
+import pytest
+
+from utils import RateLimiter, time
+
+pytestmark = pytest.mark.integration
+
+
+def test_rate_limiter_is_thread_safe(monkeypatch):
+    """Multiple concurrent calls should respect the configured capacity."""
+
+    limiter = RateLimiter(3)
+    key = "198.51.100.8"
+
+    base_time = time.time()
+    lock = threading.Lock()
+
+    def fixed_time() -> float:
+        with lock:
+            return base_time
+
+    # SECURITY: ensure deterministic timing so replenishment cannot bypass limits.
+    monkeypatch.setattr(time, "time", fixed_time)
+
+    def invoke() -> bool:
+        return limiter.check(key)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        results = list(executor.map(lambda _: invoke(), range(10)))
+
+    # Allowing for scheduling jitter, we only require "at most" capacity successes.
+    assert 0 < results.count(True) <= limiter.capacity
+    assert results.count(False) >= len(results) - limiter.capacity

--- a/tests/integration/test_storage_flows.py
+++ b/tests/integration/test_storage_flows.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import main
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def sample_history() -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi!"},
+    ]
+
+
+def test_save_and_load_round_trip(app_storage, sample_history):
+    conversations = [
+        {"id": "c1", "title": "Test", "history": sample_history},
+    ]
+
+    main.save_conversations(conversations)
+
+    on_disk = json.loads(app_storage.conversations_file.read_text(encoding="utf-8"))
+    assert on_disk == conversations
+
+    loaded = main.load_conversations()
+    assert loaded == conversations
+
+
+def test_export_and_reimport_history(app_storage, sample_history):
+    export_path = Path(main.export_handler(sample_history))
+
+    assert export_path.exists()
+    assert export_path.parent == app_storage.data_dir
+
+    exported = json.loads(export_path.read_text(encoding="utf-8"))
+    assert exported == sample_history
+
+    imported = main.import_handler(str(export_path), sample_history)
+    assert isinstance(imported, list)
+    assert imported == sample_history

--- a/tests/integration/test_streaming_chat.py
+++ b/tests/integration/test_streaming_chat.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import csv
+from types import SimpleNamespace
+
+import pytest
+
+import main
+
+pytestmark = pytest.mark.integration
+
+
+def test_chat_fn_streams_incremental_tokens(
+    fake_openai_stream,
+    mock_openai_client,
+    app_storage,
+):
+    """Ensure ``chat_fn`` yields incremental completions and logs usage."""
+
+    stream = fake_openai_stream(["Hello", " world", None])
+    mock_openai_client.queue_stream(stream)
+
+    request = SimpleNamespace(client=SimpleNamespace(host="203.0.113.5"))
+
+    generator = main.chat_fn(
+        message="Hi there",
+        history=[],
+        model=main.settings.default_model,
+        temperature=0.1,
+        system_prompt="System safety",
+        request=request,
+    )
+
+    outputs = list(generator)
+
+    # Streaming should provide partial updates culminating in the final message.
+    assert outputs == ["Hello", "Hello world"]
+    assert mock_openai_client.calls, "Expected OpenRouter client to be invoked"
+
+    # Usage logging should capture the request in the redirected CSV file.
+    with app_storage.usage_log.open("r", encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        rows = list(reader)
+    assert rows[0] == [
+        "ts",
+        "ip",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "latency_ms",
+        "cost_estimate",
+    ]
+    assert len(rows) == 2
+    assert rows[1][1] == "203.0.113.5"
+    assert rows[1][2] == main.settings.default_model


### PR DESCRIPTION
## Summary
- extend pytest configuration with integration and e2e markers
- update shared fixtures to provide isolated storage and quiet logging for IO-heavy tests
- add integration suites covering chat streaming, persistence/export flows, and rate limiter concurrency
- add an end-to-end workflow test simulating conversation lifecycle

## Testing
- pytest tests/integration -v  # fails because coverage fail-under expects the full suite
- pytest --no-cov tests/integration -v
- pytest --no-cov tests/e2e -v

------
https://chatgpt.com/codex/tasks/task_e_68d9c6b6fce483228a204e717dc2f5ed